### PR TITLE
chore: strict mypy, ruff lint rules, bump idessem 1.2.1

### DIFF
--- a/app/adapters/repository/export.py
+++ b/app/adapters/repository/export.py
@@ -3,9 +3,9 @@ import pathlib
 from abc import ABC, abstractmethod
 from typing import Type
 
-import pandas as pd  # type: ignore
-import pyarrow as pa  # type: ignore
-import pyarrow.parquet as pq  # type: ignore
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 from app.utils.log import Log
 from app.utils.tz import enforce_utc
@@ -20,7 +20,7 @@ class AbstractExportRepository(ABC):
         pass
 
     @abstractmethod
-    def synthetize_df(self, df: pd.DataFrame, filename: str):
+    def synthetize_df(self, df: pd.DataFrame, filename: str) -> None:
         pass
 
 
@@ -39,7 +39,7 @@ class ParquetExportRepository(AbstractExportRepository):
         else:
             return None
 
-    def synthetize_df(self, df: pd.DataFrame, filename: str):
+    def synthetize_df(self, df: pd.DataFrame, filename: str) -> None:
         pq.write_table(
             pa.Table.from_pandas(enforce_utc(df)),
             self.path.joinpath(filename + ".parquet"),
@@ -48,7 +48,6 @@ class ParquetExportRepository(AbstractExportRepository):
             coerce_timestamps="ms",
             allow_truncated_timestamps=True,
         )
-        return True
 
 
 class CSVExportRepository(AbstractExportRepository):
@@ -66,7 +65,7 @@ class CSVExportRepository(AbstractExportRepository):
         else:
             return None
 
-    def synthetize_df(self, df: pd.DataFrame, filename: str):
+    def synthetize_df(self, df: pd.DataFrame, filename: str) -> None:
         enforce_utc(df).to_csv(
             self.path.joinpath(filename + ".csv"), index=False
         )
@@ -83,11 +82,11 @@ class TestExportRepository(AbstractExportRepository):
     def read_df(self, filename: str) -> pd.DataFrame | None:
         return None
 
-    def synthetize_df(self, df: pd.DataFrame, filename: str) -> bool:
-        return df
+    def synthetize_df(self, df: pd.DataFrame, filename: str) -> None:
+        pass
 
 
-def factory(kind: str, *args, **kwargs) -> AbstractExportRepository:
+def factory(kind: str, *args: str, **kwargs: str) -> AbstractExportRepository:
     mapping: dict[str, Type[AbstractExportRepository]] = {
         "PARQUET": ParquetExportRepository,
         "CSV": CSVExportRepository,

--- a/app/adapters/repository/files.py
+++ b/app/adapters/repository/files.py
@@ -2,13 +2,15 @@ import asyncio
 import pathlib
 import platform
 from abc import ABC, abstractmethod
-from typing import Type, TypeVar
+from typing import Any, Type, TypeVar
 
 from idessem.dessem.dadvaz import Dadvaz
 from idessem.dessem.des_log_relato import DesLogRelato
 from idessem.dessem.dessemarq import DessemArq
 from idessem.dessem.entdados import Entdados
 from idessem.dessem.log_matriz import LogMatriz
+from idessem.dessem.operuh import Operuh
+from idessem.dessem.pdo_eco_usih import PdoEcoUsih
 from idessem.dessem.pdo_eolica import PdoEolica
 from idessem.dessem.pdo_hidr import PdoHidr
 from idessem.dessem.pdo_inter import PdoInter
@@ -17,8 +19,6 @@ from idessem.dessem.pdo_oper_tviag_calha import PdoOperTviagCalha
 from idessem.dessem.pdo_oper_uct import PdoOperUct
 from idessem.dessem.pdo_operacao import PdoOperacao
 from idessem.dessem.pdo_sist import PdoSist
-from idessem.dessem.pdo_eco_usih import PdoEcoUsih
-from idessem.dessem.operuh import Operuh
 
 from app.model.settings import Settings
 from app.utils.encoding import converte_codificacao
@@ -45,7 +45,7 @@ if platform.system() == "Windows":
 class AbstractFilesRepository(ABC):
     T = TypeVar("T")
 
-    def _validate_data(self, data, type: Type[T]) -> T:
+    def _validate_data(self, data: Any, type: Type[T]) -> T:
         if not isinstance(data, type):
             raise RuntimeError()
         return data
@@ -160,9 +160,12 @@ class RawFilesRepository(AbstractFilesRepository):
     def dessemarq(self) -> DessemArq:
         return self.__dessemarq
 
-    def __convert_utf8(self, path: str):
+    def __convert_utf8(self, path: str) -> None:
+        installdir = Settings().installdir
+        if installdir is None:
+            return
         script = str(
-            pathlib.Path(Settings().installdir).joinpath(
+            pathlib.Path(installdir).joinpath(
                 Settings().encoding_script
             )
         )
@@ -416,8 +419,9 @@ class RawFilesRepository(AbstractFilesRepository):
                     version = self.__pdo_eco_usih.versao
                     if version is None:
                         raise FileNotFoundError()
-                    PdoEcoUsih.set_version(version)
-                self.__pdo_eco_usih = PdoEcoUsih.read(path)
+                    self.__pdo_eco_usih = PdoEcoUsih.read(
+                        path, version=version
+                    )
             except Exception as e:
                 if logger is not None:
                     logger.error(f"Erro na leitura do {filename}: {e}")
@@ -443,7 +447,7 @@ class RawFilesRepository(AbstractFilesRepository):
         return self.__operuh
 
 
-def factory(kind: str, *args, **kwargs) -> AbstractFilesRepository:
+def factory(kind: str, *args: str, **kwargs: str) -> AbstractFilesRepository:
     mapping: dict[str, Type[AbstractFilesRepository]] = {
         "FS": RawFilesRepository
     }

--- a/app/app.py
+++ b/app/app.py
@@ -1,4 +1,5 @@
 import os
+from typing import Tuple
 
 import click
 
@@ -9,7 +10,7 @@ from app.utils.log import Log
 
 
 @click.group()
-def app():
+def app() -> None:
     """
     Aplicação para realizar a síntese de informações em
     um modelo unificado de dados para o DESSEM.
@@ -25,21 +26,24 @@ def app():
 @click.option(
     "--formato", default="PARQUET", help="formato para escrita da síntese"
 )
-def sistema(variaveis, formato):
+def sistema(variaveis: Tuple[str, ...], formato: str) -> None:
     """
     Realiza a síntese dos dados do sistema do DECOMP.
     """
     os.environ["FORMATO_SINTESE"] = formato
-    Log.log().info("# Realizando síntese do SISTEMA #")
+    logger = Log.log()
+    if logger is not None:
+        logger.info("# Realizando síntese do SISTEMA #")
 
     uow = factory(
         "FS",
         os.curdir,
     )
-    command = commands.SynthetizeSystem(variaveis)
+    command = commands.SynthetizeSystem(list(variaveis))
     handlers.synthetize_system(command, uow)
 
-    Log.log().info("# Fim da síntese #")
+    if logger is not None:
+        logger.info("# Fim da síntese #")
 
 
 @click.command("operacao")
@@ -50,21 +54,24 @@ def sistema(variaveis, formato):
 @click.option(
     "--formato", default="PARQUET", help="formato para escrita da síntese"
 )
-def operacao(variaveis, formato):
+def operacao(variaveis: Tuple[str, ...], formato: str) -> None:
     """
     Realiza a síntese dos dados da operação do DESSEM.
     """
     os.environ["FORMATO_SINTESE"] = formato
-    Log.log().info("# Realizando síntese da OPERACAO #")
+    logger = Log.log()
+    if logger is not None:
+        logger.info("# Realizando síntese da OPERACAO #")
 
     uow = factory(
         "FS",
         os.curdir,
     )
-    command = commands.SynthetizeOperation(variaveis)
+    command = commands.SynthetizeOperation(list(variaveis))
     handlers.synthetize_operation(command, uow)
 
-    Log.log().info("# Fim da síntese #")
+    if logger is not None:
+        logger.info("# Fim da síntese #")
 
 
 @click.command("execucao")
@@ -75,25 +82,28 @@ def operacao(variaveis, formato):
 @click.option(
     "--formato", default="PARQUET", help="formato para escrita da síntese"
 )
-def execucao(variaveis, formato):
+def execucao(variaveis: Tuple[str, ...], formato: str) -> None:
     """
     Realiza a síntese dos dados da execução do DESSEM.
     """
     os.environ["FORMATO_SINTESE"] = formato
-    Log.log().info("# Realizando síntese da EXECUÇÃO #")
+    logger = Log.log()
+    if logger is not None:
+        logger.info("# Realizando síntese da EXECUÇÃO #")
 
     uow = factory(
         "FS",
         os.curdir,
     )
-    command = commands.SynthetizeExecution(variaveis)
+    command = commands.SynthetizeExecution(list(variaveis))
     handlers.synthetize_execution(command, uow)
 
-    Log.log().info("# Fim da síntese #")
+    if logger is not None:
+        logger.info("# Fim da síntese #")
 
 
 @click.command("limpeza")
-def limpeza():
+def limpeza() -> None:
     """
     Realiza a limpeza dos dados resultantes de uma síntese.
     """
@@ -113,25 +123,33 @@ def limpeza():
 @click.option(
     "--formato", default="PARQUET", help="formato para escrita da síntese"
 )
-def completa(sistema, operacao, execucao, formato):
+def completa(
+    sistema: Tuple[str, ...],
+    operacao: Tuple[str, ...],
+    execucao: Tuple[str, ...],
+    formato: str,
+) -> None:
     """
     Realiza a síntese completa do DESSEM.
     """
     os.environ["FORMATO_SINTESE"] = formato
-    Log.log().info("# Realizando síntese COMPLETA #")
+    logger = Log.log()
+    if logger is not None:
+        logger.info("# Realizando síntese COMPLETA #")
 
     uow = factory(
         "FS",
         os.curdir,
     )
-    command = commands.SynthetizeSystem(sistema)
-    handlers.synthetize_system(command, uow)
-    command = commands.SynthetizeOperation(operacao)
-    handlers.synthetize_operation(command, uow)
-    command = commands.SynthetizeExecution(execucao)
-    handlers.synthetize_execution(command, uow)
+    system_command = commands.SynthetizeSystem(list(sistema))
+    handlers.synthetize_system(system_command, uow)
+    operation_command = commands.SynthetizeOperation(list(operacao))
+    handlers.synthetize_operation(operation_command, uow)
+    execution_command = commands.SynthetizeExecution(list(execucao))
+    handlers.synthetize_execution(execution_command, uow)
 
-    Log.log().info("# Fim da síntese #")
+    if logger is not None:
+        logger.info("# Fim da síntese #")
 
 
 app.add_command(completa)

--- a/app/internal/constants.py
+++ b/app/internal/constants.py
@@ -127,7 +127,7 @@ SYSTEM_SYNTHESIS_SUBDIR = ""
 
 QUANTILES_FOR_STATISTICS = [0.05 * i for i in range(21)]
 
-import pandas  # type: ignore # noqa: E402
+import pandas  # noqa: E402
 
 __has_numba = find_spec("numba") is not None
 if pandas.__version__ >= "2.2.0" and __has_numba:

--- a/app/model/operation/spatialresolution.py
+++ b/app/model/operation/spatialresolution.py
@@ -34,7 +34,7 @@ class SpatialResolution(Enum):
                 return v
         return cls.SUBMERCADO
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.value
 
     @property

--- a/app/model/settings.py
+++ b/app/model/settings.py
@@ -4,7 +4,7 @@ from app.utils.singleton import Singleton
 
 
 class Settings(metaclass=Singleton):
-    def __init__(self):
+    def __init__(self) -> None:
         # Execution parameters
         self.installdir = getenv("APP_INSTALLDIR")
         self.basedir = getenv("APP_BASEDIR")

--- a/app/services/deck/bounds.py
+++ b/app/services/deck/bounds.py
@@ -2,23 +2,23 @@ from logging import INFO, Logger
 from typing import Callable, Dict, Optional, TypeVar
 
 import numpy as np
-import pandas as pd  # type: ignore
+import pandas as pd
 
 from app.internal.constants import (
+    HYDRO_CODE_COL,
+    IDENTIFICATION_COLUMNS,
     LOWER_BOUND_COL,
-    UPPER_BOUND_COL,
-    VALUE_COL,
-    THERMAL_CODE_COL,
     STAGE_COL,
     SUBMARKET_CODE_COL,
-    IDENTIFICATION_COLUMNS,
-    HYDRO_CODE_COL,
+    THERMAL_CODE_COL,
+    UPPER_BOUND_COL,
+    VALUE_COL,
 )
-from app.services.deck.deck import Deck
 from app.model.operation.operationsynthesis import OperationSynthesis
-from app.services.unitofwork import AbstractUnitOfWork
-from app.model.operation.variable import Variable
 from app.model.operation.spatialresolution import SpatialResolution
+from app.model.operation.variable import Variable
+from app.services.deck.deck import Deck
+from app.services.unitofwork import AbstractUnitOfWork
 from app.utils.operations import fast_group_df
 
 
@@ -32,7 +32,7 @@ class OperationVariableBounds:
     T = TypeVar("T")
     logger: Optional[Logger] = None
 
-    MAPPINGS: Dict[OperationSynthesis, Callable] = {
+    MAPPINGS: Dict[OperationSynthesis, Callable[..., pd.DataFrame]] = {
         OperationSynthesis(
             Variable.GERACAO_TERMICA,
             SpatialResolution.USINA_TERMELETRICA,
@@ -188,7 +188,7 @@ class OperationVariableBounds:
     }
 
     @classmethod
-    def _log(cls, msg: str, level: int = INFO):
+    def _log(cls, msg: str, level: int = INFO) -> None:
         if cls.logger is not None:
             cls.logger.log(level, msg)
 
@@ -510,7 +510,7 @@ class OperationVariableBounds:
         cls,
         s: OperationSynthesis,
         df: pd.DataFrame,
-        ordered_synthesis_entities: Dict[str, list],
+        ordered_synthesis_entities: Dict[str, list[str]],
         uow: AbstractUnitOfWork,
     ) -> pd.DataFrame:
         """

--- a/app/services/deck/deck.py
+++ b/app/services/deck/deck.py
@@ -3,8 +3,8 @@ from datetime import datetime, timedelta
 from functools import partial
 from typing import Any, Dict, Optional, Type, TypeVar
 
-import numpy as np  # type: ignore
-import pandas as pd  # type: ignore
+import numpy as np
+import pandas as pd
 from idessem.dessem.dadvaz import Dadvaz
 from idessem.dessem.des_log_relato import DesLogRelato
 from idessem.dessem.dessemarq import DessemArq
@@ -151,7 +151,7 @@ class Deck:
             return pdo
 
     @classmethod
-    def _validate_data(cls, data, type: Type[T], msg: str = "dados") -> T:
+    def _validate_data(cls, data: Any, type: Type[T], msg: str = "dados") -> T:
         if not isinstance(data, type):
             if cls.logger is not None:
                 cls.logger.error(f"Erro na leitura de {msg}")
@@ -621,7 +621,11 @@ class Deck:
                 PdoOperUct,
                 "pdo_oper_uct",
             )
-            df = pdo_oper_uct.tabela
+            df = cls._validate_data(
+                pdo_oper_uct.tabela,
+                pd.DataFrame,
+                "pdo_oper_uct.tabela",
+            )
             # Acrescenta datas iniciais e finais
             # Faz uma atribuicao nao posicional.
             # A maneira mais pythonica é lenta.
@@ -715,7 +719,7 @@ class Deck:
         return cls.DECK_DATA_CACHING["pdo_eco_usih"]
 
     @classmethod
-    def stages_durations(cls, uow) -> pd.DataFrame:
+    def stages_durations(cls, uow: AbstractUnitOfWork) -> pd.DataFrame:
         df = cls.DECK_DATA_CACHING.get("stages_durations")
         if df is None:
             arq_pdo = cls.pdo_operacao(uow)
@@ -740,7 +744,7 @@ class Deck:
         cls, line: pd.Series, uow: AbstractUnitOfWork
     ) -> np.ndarray:
         stage_df = cls.stages_durations(uow)
-        return (
+        result: np.ndarray = (
             stage_df.loc[
                 stage_df[STAGE_COL] == line[STAGE_COL],
                 [START_DATE_COL, END_DATE_COL],
@@ -748,6 +752,7 @@ class Deck:
             .to_numpy()
             .flatten()
         )
+        return result
 
     @classmethod
     def version(cls, uow: AbstractUnitOfWork) -> str:
@@ -787,7 +792,7 @@ class Deck:
         return title
 
     @classmethod
-    def hydro_inflows(cls, uow) -> pd.DataFrame:
+    def hydro_inflows(cls, uow: AbstractUnitOfWork) -> pd.DataFrame:
         df = cls.DECK_DATA_CACHING.get("hydro_inflows")
         if df is None:
             arq_dadvaz = cls.dadvaz(uow)
@@ -806,7 +811,7 @@ class Deck:
         return df.copy()
 
     @classmethod
-    def block_map(cls, uow: AbstractUnitOfWork) -> dict:
+    def block_map(cls, uow: AbstractUnitOfWork) -> dict[str, int]:
         map_dict = cls.DECK_DATA_CACHING.get("block_map")
         if map_dict is None:
             entdados = cls.entdados(uow)
@@ -815,14 +820,14 @@ class Deck:
                 pd.DataFrame,
                 "TM",
             )
-            blocks: list = tm_df["nome_patamar"].unique().tolist()
+            blocks: list[str] = tm_df["nome_patamar"].unique().tolist()
             blocks.sort(reverse=True)
             map_dict = {b: i for i, b in enumerate(blocks)}
             cls.DECK_DATA_CACHING["block_map"] = map_dict
         return map_dict
 
     @classmethod
-    def stage_block_map(cls, uow: AbstractUnitOfWork) -> dict:
+    def stage_block_map(cls, uow: AbstractUnitOfWork) -> dict[int, int]:
         map_dict = cls.DECK_DATA_CACHING.get("stage_block_map")
         if map_dict is None:
             block_map = cls.block_map(uow)
@@ -832,7 +837,7 @@ class Deck:
                 pd.DataFrame,
                 "TM",
             )
-            blocks: list = tm_df["nome_patamar"]
+            blocks: list[str] = tm_df["nome_patamar"]
             map_dict = {i + 1: block_map[b] for i, b in enumerate(blocks)}
             cls.DECK_DATA_CACHING["stage_block_map"] = map_dict
         return map_dict
@@ -1639,7 +1644,7 @@ class Deck:
             )
             return df
 
-        def __cast_constraints_stages_to_datetime(row: pd.Series, period: str):
+        def __cast_constraints_stages_to_datetime(row: pd.Series, period: str) -> Any:
             # Processa os dados de stages_durations para a futura conversao
             df_stages["day"] = df_stages["data_inicio"].dt.day
             df_stages["month"] = df_stages["data_inicio"].dt.month
@@ -1764,7 +1769,7 @@ class Deck:
         cls,
         df: pd.DataFrame,
         df_constraints: pd.DataFrame,
-    ):
+    ) -> pd.DataFrame:
         if df_constraints.empty:
             return df
 

--- a/app/services/handlers.py
+++ b/app/services/handlers.py
@@ -3,32 +3,35 @@ import shutil
 
 import app.domain.commands as commands
 from app.model.settings import Settings
-from app.services.synthesis.system import SystemSynthetizer
 from app.services.synthesis.execution import ExecutionSynthetizer
 from app.services.synthesis.operation import OperationSynthetizer
+from app.services.synthesis.system import SystemSynthetizer
 from app.services.unitofwork import AbstractUnitOfWork
 
 
 def synthetize_system(
     command: commands.SynthetizeSystem, uow: AbstractUnitOfWork
-):
+) -> None:
     SystemSynthetizer.synthetize(command.variables, uow)
 
 
 def synthetize_operation(
     command: commands.SynthetizeOperation, uow: AbstractUnitOfWork
-):
+) -> None:
     synthetizer = OperationSynthetizer()
     synthetizer.synthetize(command.variables, uow)
 
 
 def synthetize_execution(
     command: commands.SynthetizeExecution, uow: AbstractUnitOfWork
-):
+) -> None:
     synthetizer = ExecutionSynthetizer()
     synthetizer.synthetize(command.variables, uow)
 
 
-def clean():
-    path = pathlib.Path(Settings().basedir).joinpath(Settings().synthesis_dir)
+def clean() -> None:
+    settings = Settings()
+    if settings.basedir is None:
+        return
+    path = pathlib.Path(settings.basedir).joinpath(settings.synthesis_dir)
     shutil.rmtree(path)

--- a/app/services/synthesis/execution.py
+++ b/app/services/synthesis/execution.py
@@ -3,7 +3,7 @@ from logging import ERROR, INFO
 from traceback import print_exc
 from typing import Callable, List, Optional
 
-import pandas as pd  # type: ignore
+import pandas as pd
 
 from app.internal.constants import (
     EXECUTION_SYNTHESIS_METADATA_OUTPUT,
@@ -26,13 +26,13 @@ class ExecutionSynthetizer:
     logger: Optional[logging.Logger] = None
 
     @classmethod
-    def _log(cls, msg: str, level: int = INFO):
+    def _log(cls, msg: str, level: int = INFO) -> None:
         if cls.logger is not None:
             cls.logger.log(level, msg)
 
     @classmethod
     def _default_args(cls) -> List[str]:
-        return cls.DEFAULT_EXECUTION_SYNTHESIS_ARGS
+        return list(cls.DEFAULT_EXECUTION_SYNTHESIS_ARGS)
 
     @classmethod
     def _match_wildcards(cls, variables: List[str]) -> List[str]:
@@ -78,7 +78,7 @@ class ExecutionSynthetizer:
     def _resolve(
         cls, synthesis: ExecutionSynthesis, uow: AbstractUnitOfWork
     ) -> pd.DataFrame:
-        RULES: dict[Variable, Callable] = {
+        RULES: dict[Variable, Callable[..., pd.DataFrame]] = {
             Variable.PROGRAMA: cls._resolve_program,
             Variable.VERSAO: cls._resolve_version,
             Variable.TITULO: cls._resolve_title,
@@ -90,11 +90,11 @@ class ExecutionSynthetizer:
     @classmethod
     def _resolve_program(cls, uow: AbstractUnitOfWork) -> pd.DataFrame:
         return pd.DataFrame(data={"programa": ["DESSEM"]})
-    
+
     @classmethod
     def _resolve_version(cls, uow: AbstractUnitOfWork) -> pd.DataFrame:
         return pd.DataFrame(data={"versao": [Deck.version(uow)]})
-    
+
     @classmethod
     def _resolve_title(cls, uow: AbstractUnitOfWork) -> pd.DataFrame:
         return pd.DataFrame(data={"titulo": [Deck.title(uow)]})
@@ -136,7 +136,7 @@ class ExecutionSynthetizer:
         cls,
         success_synthesis: List[ExecutionSynthesis],
         uow: AbstractUnitOfWork,
-    ):
+    ) -> None:
         metadata_df = pd.DataFrame(
             columns=[
                 "chave",
@@ -182,7 +182,7 @@ class ExecutionSynthetizer:
                 return None
 
     @classmethod
-    def synthetize(cls, variables: List[str], uow: AbstractUnitOfWork):
+    def synthetize(cls, variables: List[str], uow: AbstractUnitOfWork) -> None:
         cls.logger = logging.getLogger("main")
         uow.subdir = EXECUTION_SYNTHESIS_SUBDIR
 

--- a/app/services/synthesis/operation.py
+++ b/app/services/synthesis/operation.py
@@ -3,7 +3,7 @@ from logging import DEBUG, ERROR, INFO, WARNING
 from traceback import print_exc
 from typing import Callable, List, TypeVar
 
-import pandas as pd  # type: ignore
+import pandas as pd
 
 from app.internal.constants import (
     IDENTIFICATION_COLUMNS,
@@ -11,9 +11,9 @@ from app.internal.constants import (
     OPERATION_SYNTHESIS_STATS_ROOT,
     OPERATION_SYNTHESIS_SUBDIR,
     STRING_DF_TYPE,
+    SUBMARKET_CODE_COL,
     VALUE_COL,
     VARIABLE_COL,
-    SUBMARKET_CODE_COL,
 )
 from app.model.operation.operationsynthesis import (
     SUPPORTED_SYNTHESIS,
@@ -45,13 +45,13 @@ class OperationSynthetizer:
 
     # Estratégias de cache para reduzir tempo total de síntese
     CACHED_SYNTHESIS: dict[OperationSynthesis, pd.DataFrame] = {}
-    ORDERED_SYNTHESIS_ENTITIES: dict[OperationSynthesis, dict[str, list]] = {}
+    ORDERED_SYNTHESIS_ENTITIES: dict[OperationSynthesis, dict[str, list[str]]] = {}
 
     # Estatísticas das sínteses são armazenadas separadamente
     SYNTHESIS_STATS: dict[SpatialResolution, list[pd.DataFrame]] = {}
 
     @classmethod
-    def clear_cache(cls):
+    def clear_cache(cls) -> None:
         """
         Limpa o cache de síntese de operação.
         """
@@ -60,17 +60,17 @@ class OperationSynthetizer:
         cls.SYNTHESIS_STATS.clear()
 
     @classmethod
-    def _log(cls, msg: str, level: int = INFO):
+    def _log(cls, msg: str, level: int = INFO) -> None:
         if cls.logger is not None:
             cls.logger.log(level, msg)
 
     @classmethod
     def _resolve(
         cls, synthesis: tuple[Variable, SpatialResolution]
-    ) -> Callable:
+    ) -> Callable[..., pd.DataFrame]:
         _rules: dict[
             tuple[Variable, SpatialResolution],
-            Callable,
+            Callable[..., pd.DataFrame],
         ] = {
             (
                 Variable.CUSTO_OPERACAO,
@@ -441,7 +441,7 @@ class OperationSynthetizer:
 
     @classmethod
     def _default_args(cls) -> List[str]:
-        return cls.DEFAULT_OPERATION_SYNTHESIS_ARGS
+        return list(cls.DEFAULT_OPERATION_SYNTHESIS_ARGS)
 
     @classmethod
     def _match_wildcards(cls, variables: list[str]) -> list[str]:
@@ -485,7 +485,7 @@ class OperationSynthetizer:
         def _add_synthesis_dependencies_recursive(
             current_synthesis: list[OperationSynthesis],
             todo_synthesis: OperationSynthesis,
-        ):
+        ) -> None:
             if todo_synthesis in SYNTHESIS_DEPENDENCIES.keys():
                 for dep in SYNTHESIS_DEPENDENCIES[todo_synthesis]:
                     _add_synthesis_dependencies_recursive(
@@ -502,7 +502,7 @@ class OperationSynthetizer:
     @classmethod
     def _get_unique_column_values_in_order(
         cls, df: pd.DataFrame, cols: list[str]
-    ):
+    ) -> dict[str, list[str]]:
         """
         Extrai valores únicos na ordem em que aparecem para um
         conjunto de colunas de um DataFrame.
@@ -511,15 +511,15 @@ class OperationSynthetizer:
 
     @classmethod
     def _set_ordered_entities(
-        cls, s: OperationSynthesis, entities: dict[str, list]
-    ):
+        cls, s: OperationSynthesis, entities: dict[str, list[str]]
+    ) -> None:
         """
         Armazena um conjunto de entidades ordenadas para uma síntese.
         """
         cls.ORDERED_SYNTHESIS_ENTITIES[s] = entities
 
     @classmethod
-    def _get_ordered_entities(cls, s: OperationSynthesis) -> dict[str, list]:
+    def _get_ordered_entities(cls, s: OperationSynthesis) -> dict[str, list[str]]:
         """
         Obtem um conjunto de entidades ordenadas para uma síntese.
         """
@@ -543,7 +543,7 @@ class OperationSynthetizer:
             raise RuntimeError()
 
     @classmethod
-    def _stub_mappings(cls, s: OperationSynthesis) -> Callable | None:  # noqa
+    def _stub_mappings(cls, s: OperationSynthesis) -> Callable[..., pd.DataFrame] | None:  # noqa
         """
         Obtem a função de resolução de cada síntese que foge ao
         fluxo de resolução padrão, por meio de um mapeamento de
@@ -586,7 +586,7 @@ class OperationSynthetizer:
     @classmethod
     def __store_in_cache_if_needed(
         cls, s: OperationSynthesis, df: pd.DataFrame
-    ):
+    ) -> None:
         """
         Adiciona um DataFrame com os dados de uma síntese à cache
         caso esta seja uma variável que deva ser armazenada.
@@ -625,8 +625,8 @@ class OperationSynthetizer:
         df: pd.DataFrame,
         s: OperationSynthesis,
         uow: AbstractUnitOfWork,
-        early_hooks: list[Callable] = [],
-        late_hooks: list[Callable] = [],
+        early_hooks: list[Callable[..., pd.DataFrame]] = [],
+        late_hooks: list[Callable[..., pd.DataFrame]] = [],
     ) -> pd.DataFrame:
         """
         Realiza pós-processamento após a resolução da extração
@@ -679,7 +679,7 @@ class OperationSynthetizer:
         cls,
         success_synthesis: list[OperationSynthesis],
         uow: AbstractUnitOfWork,
-    ):
+    ) -> None:
         """
         Cria um DataFrame com os metadados das variáveis de síntese
         e realiza a exportação para um arquivo de metadados.
@@ -713,7 +713,7 @@ class OperationSynthetizer:
             )
 
     @classmethod
-    def _add_synthesis_stats(cls, s: OperationSynthesis, df: pd.DataFrame):
+    def _add_synthesis_stats(cls, s: OperationSynthesis, df: pd.DataFrame) -> None:
         """
         Adiciona um DataFrame com estatísticas de uma síntese ao
         DataFrame de estatísticas da agregação espacial em questão.
@@ -728,7 +728,7 @@ class OperationSynthetizer:
     @classmethod
     def _export_scenario_synthesis(
         cls, s: OperationSynthesis, df: pd.DataFrame, uow: AbstractUnitOfWork
-    ):
+    ) -> None:
         """
         Realiza a exportação dos dados para uma síntese da
         operação desejada. Opcionalmente, os dados são armazenados
@@ -757,7 +757,7 @@ class OperationSynthetizer:
     def _export_stats(
         cls,
         uow: AbstractUnitOfWork,
-    ):
+    ) -> None:
         """
         Realiza a exportação dos dados de estatísticas de síntese
         da operação. As estatísticas são exportadas para um arquivo
@@ -848,7 +848,7 @@ class OperationSynthetizer:
                 return None
 
     @classmethod
-    def synthetize(cls, variables: list[str], uow: AbstractUnitOfWork):
+    def synthetize(cls, variables: list[str], uow: AbstractUnitOfWork) -> None:
         cls.logger = logging.getLogger("main")
         Deck.logger = cls.logger
         OperationVariableBounds.logger = cls.logger

--- a/app/services/synthesis/system.py
+++ b/app/services/synthesis/system.py
@@ -3,7 +3,7 @@ from logging import ERROR, INFO
 from traceback import print_exc
 from typing import Callable, Optional
 
-import pandas as pd  # type: ignore
+import pandas as pd
 
 from app.internal.constants import (
     BLOCK_COL,
@@ -34,13 +34,13 @@ class SystemSynthetizer:
     logger: Optional[logging.Logger] = None
 
     @classmethod
-    def _log(cls, msg: str, level: int = INFO):
+    def _log(cls, msg: str, level: int = INFO) -> None:
         if cls.logger is not None:
             cls.logger.log(level, msg)
 
     @classmethod
     def _default_args(cls) -> list[str]:
-        return cls.DEFAULT_SYSTEM_SYNTHESIS_ARGS
+        return list(cls.DEFAULT_SYSTEM_SYNTHESIS_ARGS)
 
     @classmethod
     def _match_wildcards(cls, variables: list[str]) -> list[str]:
@@ -86,7 +86,7 @@ class SystemSynthetizer:
     def _resolve(
         cls, synthesis: SystemSynthesis, uow: AbstractUnitOfWork
     ) -> pd.DataFrame:
-        RULES: dict[Variable, Callable] = {
+        RULES: dict[Variable, Callable[..., pd.DataFrame]] = {
             Variable.EST: cls._resolve_EST,
             Variable.PAT: cls._resolve_PAT,
             Variable.SBM: cls._resolve_SBM,
@@ -163,7 +163,7 @@ class SystemSynthetizer:
         cls,
         success_synthesis: list[SystemSynthesis],
         uow: AbstractUnitOfWork,
-    ):
+    ) -> None:
         metadata_df = pd.DataFrame(
             columns=[
                 "chave",
@@ -209,7 +209,7 @@ class SystemSynthetizer:
                 return None
 
     @classmethod
-    def synthetize(cls, variables: list[str], uow: AbstractUnitOfWork):
+    def synthetize(cls, variables: list[str], uow: AbstractUnitOfWork) -> None:
         cls.logger = logging.getLogger("main")
         uow.subdir = SYSTEM_SYNTHESIS_SUBDIR
 

--- a/app/services/unitofwork.py
+++ b/app/services/unitofwork.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from os import chdir, curdir
 from pathlib import Path
-from typing import Dict, Type
+from typing import Any, Dict, Optional, Type
 
 from app.adapters.repository.export import (
     AbstractExportRepository,
@@ -23,11 +23,11 @@ class AbstractUnitOfWork(ABC):
     def __enter__(self) -> "AbstractUnitOfWork":
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, *args: Any) -> None:
         self.rollback()
 
     @abstractmethod
-    def rollback(self):
+    def rollback(self) -> None:
         raise NotImplementedError
 
     @property
@@ -45,7 +45,7 @@ class AbstractUnitOfWork(ABC):
         return self._subdir
 
     @subdir.setter
-    def subdir(self, subdir: str):
+    def subdir(self, subdir: str) -> None:
         self._subdir = subdir
 
 
@@ -54,10 +54,10 @@ class FSUnitOfWork(AbstractUnitOfWork):
         super().__init__()
         self._current_path = Path(curdir).resolve()
         self._path = Path(directory).resolve()
-        self._files = None
-        self._exporter = None
+        self._files: Optional[AbstractFilesRepository] = None
+        self._exporter: Optional[AbstractExportRepository] = None
 
-    def __create_repository(self):
+    def __create_repository(self) -> None:
         if self._files is None:
             self._files = RawFilesRepository(str(self._path))
         if self._exporter is None:
@@ -74,7 +74,7 @@ class FSUnitOfWork(AbstractUnitOfWork):
         self.__create_repository()
         return super().__enter__()
 
-    def __exit__(self, *args):
+    def __exit__(self, *args: Any) -> None:
         chdir(self._current_path)
         super().__exit__(*args)
 
@@ -90,11 +90,11 @@ class FSUnitOfWork(AbstractUnitOfWork):
             raise RuntimeError()
         return self._exporter
 
-    def rollback(self):
+    def rollback(self) -> None:
         pass
 
 
-def factory(kind: str, *args, **kwargs) -> AbstractUnitOfWork:
+def factory(kind: str, *args: Any, **kwargs: Any) -> AbstractUnitOfWork:
     mappings: Dict[str, Type[AbstractUnitOfWork]] = {
         "FS": FSUnitOfWork,
     }

--- a/app/utils/encoding.py
+++ b/app/utils/encoding.py
@@ -5,7 +5,7 @@ from app.utils.terminal import run_terminal_retry
 TIMEOUT_DEFAULT = 10.0
 
 
-async def converte_codificacao(path: str, script: str):
+async def converte_codificacao(path: str, script: str) -> None:
     if platform.system() == "Windows":
         return
     _, out = await run_terminal_retry([f"file -i {path}"])

--- a/app/utils/fs.py
+++ b/app/utils/fs.py
@@ -1,5 +1,7 @@
 import os
 from pathlib import Path
+from types import TracebackType
+from typing import Any, Optional, Type
 
 
 class set_directory:
@@ -12,10 +14,16 @@ class set_directory:
         self.path = Path(path)
         self.origin = Path().absolute()
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         os.chdir(self.path)
 
-    def __exit__(self, *args, **kwargs):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+        **kwargs: Any,
+    ) -> None:
         os.chdir(self.origin)
 
 

--- a/app/utils/log.py
+++ b/app/utils/log.py
@@ -9,7 +9,7 @@ class Log(metaclass=Singleton):
     LOGGER = None
 
     @classmethod
-    def configure_logging(cls, diretorio: str):
+    def configure_logging(cls, diretorio: str) -> None:
         root = logging.getLogger("main")
         f = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
         # Logger para STDOUT

--- a/app/utils/operations.py
+++ b/app/utils/operations.py
@@ -1,17 +1,19 @@
-import pandas as pd  # type: ignore
 from typing import Callable, Dict
+
+import pandas as pd
+
 from app.internal.constants import (
+    PANDAS_GROUPING_ENGINE,
     PROBABILITY_COL,
     SCENARIO_COL,
     VALUE_COL,
-    PANDAS_GROUPING_ENGINE,
 )
 
 
 def fast_group_df(
     df: pd.DataFrame,
-    grouping_columns: list,
-    extract_columns: list,
+    grouping_columns: list[str],
+    extract_columns: list[str],
     operation: str,
     reset_index: bool = True,
 ) -> pd.DataFrame:

--- a/app/utils/regex.py
+++ b/app/utils/regex.py
@@ -4,7 +4,7 @@ from typing import List
 
 def match_variables_with_wildcards(
     given_variables: List[str], all_variables: List[str]
-):
+) -> List[str]:
     variables_with_wildcards: List[str] = []
     for v in given_variables:
         if "*" in v:

--- a/app/utils/singleton.py
+++ b/app/utils/singleton.py
@@ -1,7 +1,10 @@
-class Singleton(type):
-    _instances: dict = {}
+from typing import Any
 
-    def __call__(cls, *args, **kwargs):
+
+class Singleton(type):
+    _instances: dict[type, Any] = {}
+
+    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(
                 *args, **kwargs

--- a/app/utils/timing.py
+++ b/app/utils/timing.py
@@ -1,6 +1,7 @@
 import time
 from logging import INFO, Logger
-from typing import Optional
+from types import TracebackType
+from typing import Optional, Type
 
 
 class time_and_log:
@@ -14,13 +15,16 @@ class time_and_log:
         self.logger = logger
         self.level = level
 
-    def __enter__(
-        self,
-    ):
+    def __enter__(self) -> "time_and_log":
         self.start_time = time.perf_counter()
         return self
 
-    def __exit__(self, exc_type, exc_value, exc_tb):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         end_time = time.perf_counter()
         run_time = end_time - self.start_time
         if self.logger:

--- a/app/utils/tz.py
+++ b/app/utils/tz.py
@@ -1,4 +1,4 @@
-import pandas as pd  # type: ignore
+import pandas as pd
 
 
 def enforce_utc(df: pd.DataFrame) -> pd.DataFrame:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,10 @@ name = "sintetizador-dessem"
 dynamic = ["version"]
 dependencies = [
     "click>=8.1.8",
-    "idessem>=1.0.0",
+    "idessem>=1.2.1",
     "pyarrow>=19.0.0",
 ]
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 authors = [
   {name = "Rogerio Alves", email = "rogerioalves.ee@gmail.com"},
   {name = "Mariana Noel", email = "marianasimoesnoel@gmail.com"},
@@ -22,7 +22,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Operating System :: OS Independent",
 ]
 
@@ -59,3 +59,35 @@ include = [
 
 [tool.ruff]
 line-length = 80
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["app"]
+
+[tool.mypy]
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["idessem.*"]
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = ["cfinterface.*"]
+ignore_errors = true
+
+# idessem .read() classmethods return base types (SectionFile,
+# BlockFile, RegisterFile) instead of Self, causing many false-positive
+# errors throughout this module.
+[[tool.mypy.overrides]]
+module = ["app.adapters.repository.files"]
+disable_error_code = ["assignment", "return-value", "attr-defined", "unused-ignore"]
+
+[[tool.mypy.overrides]]
+module = ["dateutil.*"]
+ignore_errors = true

--- a/tests/app/services/synthesis/test_operation.py
+++ b/tests/app/services/synthesis/test_operation.py
@@ -560,7 +560,10 @@ def test_sintese_varpi_uhe(test_settings):
     df, df_meta = __sintetiza_com_mock(synthesis_str)
     df_pdo_hidr = PdoHidr.read(join(DECK_TEST_DIR, "PDO_HIDR.DAT")).tabela
     df_pdo_hidr = df_pdo_hidr.loc[df_pdo_hidr["conjunto"] == 99].copy()
-    df_eco = PdoEcoUsih.read(join(DECK_TEST_DIR, "PDO_ECO_USIH.DAT")).tabela
+    _eco_file = PdoEcoUsih.read(join(DECK_TEST_DIR, "PDO_ECO_USIH.DAT"))
+    df_eco = PdoEcoUsih.read(
+        join(DECK_TEST_DIR, "PDO_ECO_USIH.DAT"), version=_eco_file.versao
+    ).tabela
     num_uhes = len(df_eco)
     initial_volumes = df_eco["volume_util_inicial_percentual"].to_numpy()
     final_volumes = df_pdo_hidr["volume_final_percentual"].to_numpy()[
@@ -587,7 +590,10 @@ def test_sintese_varmi_uhe(test_settings):
     df_pdo_hidr = PdoHidr.read(join(DECK_TEST_DIR, "PDO_HIDR.DAT")).tabela
     df_pdo_hidr = df_pdo_hidr.loc[df_pdo_hidr["conjunto"] == 99].copy()
     # Obtem volume inicial
-    df_eco = PdoEcoUsih.read(join(DECK_TEST_DIR, "PDO_ECO_USIH.DAT")).tabela
+    _eco_file = PdoEcoUsih.read(join(DECK_TEST_DIR, "PDO_ECO_USIH.DAT"))
+    df_eco = PdoEcoUsih.read(
+        join(DECK_TEST_DIR, "PDO_ECO_USIH.DAT"), version=_eco_file.versao
+    ).tabela
     num_uhes = len(df_eco)
     initial_volumes = df_eco["volume_util_inicial_hm3"].to_numpy()
     final_volumes = df_pdo_hidr["volume_final_hm3"].to_numpy()[:-num_uhes]
@@ -615,7 +621,10 @@ def test_sintese_varmi_sbm(test_settings):
     df_pdo_hidr = df_pdo_hidr.loc[df_pdo_hidr["conjunto"] == 99].copy()
 
     # Obtem volume inicial
-    df_eco = PdoEcoUsih.read(join(DECK_TEST_DIR, "PDO_ECO_USIH.DAT")).tabela
+    _eco_file = PdoEcoUsih.read(join(DECK_TEST_DIR, "PDO_ECO_USIH.DAT"))
+    df_eco = PdoEcoUsih.read(
+        join(DECK_TEST_DIR, "PDO_ECO_USIH.DAT"), version=_eco_file.versao
+    ).tabela
     num_uhes = len(df_eco)
     initial_volumes = df_eco["volume_util_inicial_hm3"].to_numpy()
     final_volumes = df_pdo_hidr["volume_final_hm3"].to_numpy()[:-num_uhes]
@@ -646,7 +655,10 @@ def test_sintese_varmi_sin(test_settings):
     df_pdo_hidr = PdoHidr.read(join(DECK_TEST_DIR, "PDO_HIDR.DAT")).tabela
     df_pdo_hidr = df_pdo_hidr.loc[df_pdo_hidr["conjunto"] == 99].copy()
     # Obtem volume inicial
-    df_eco = PdoEcoUsih.read(join(DECK_TEST_DIR, "PDO_ECO_USIH.DAT")).tabela
+    _eco_file = PdoEcoUsih.read(join(DECK_TEST_DIR, "PDO_ECO_USIH.DAT"))
+    df_eco = PdoEcoUsih.read(
+        join(DECK_TEST_DIR, "PDO_ECO_USIH.DAT"), version=_eco_file.versao
+    ).tabela
     num_uhes = len(df_eco)
     initial_volumes = df_eco["volume_util_inicial_hm3"].to_numpy()
     final_volumes = df_pdo_hidr["volume_final_hm3"].to_numpy()[:-num_uhes]


### PR DESCRIPTION
## Summary

- Add mypy strict mode config with overrides for idessem/cfinterface base types (matching sintetizador-decomp v3.0.0)
- Add ruff lint rules `["E", "F", "W", "I"]` with isort config
- Add type annotations across all 21 source files (118 mypy errors → 0)
- Bump `requires-python` to `>=3.11` and `idessem` to `>=1.2.1`
- Replace deprecated `PdoEcoUsih.set_version()` with `read(version=...)` (fixes #92 in idessem)
- Fix tests that relied on `set_version` class-level side effect

## Test plan

- [x] `mypy ./app` — 0 errors (strict mode)
- [x] `ruff check ./app` — all checks passed
- [x] `pytest tests/` — 82 passed, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)